### PR TITLE
Button fixes

### DIFF
--- a/src/components/partials/SearchResults.jsx
+++ b/src/components/partials/SearchResults.jsx
@@ -42,6 +42,7 @@ export const SearchResults = ({ searchData, searchResultsType }) => {
                             searchResult={searchResult}
                             visibleFields={["DownloadButton", "MapButton", "ApplicationButton"]}
                             key={i}
+                            stretchButtons
                         />
                     </ErrorBoundary>
                 );

--- a/src/components/partials/SearchResults/MetadataSearchResult.jsx
+++ b/src/components/partials/SearchResults/MetadataSearchResult.jsx
@@ -80,13 +80,19 @@ const MetadataSearchResult = (props) => {
             </ErrorBoundary>
         ) : null;
 
+        const containerClass = [
+            style.buttonGroupContainer,
+            props.stretchButtons ? style.stretch : null,
+            props.buttonAlignment === "left" ? style.forceLeft : null,
+        ].filter(Boolean).join(" ");
+
         return (
-    <div className={style.buttonGroupContainer}>
-        {applicationButtonElement}
-        {mapButtonElement}
-        {downloadButtonElement}
-    </div>
-);
+            <div className={containerClass}>
+                {applicationButtonElement}
+                {mapButtonElement}
+                {downloadButtonElement}
+            </div>
+        );
     };
 
     const renderDistributionFormats = () => {

--- a/src/components/partials/SearchResults/MetadataSearchResult.module.scss
+++ b/src/components/partials/SearchResults/MetadataSearchResult.module.scss
@@ -134,7 +134,20 @@
 	gap: 1rem;
 	justify-content: flex-start;
 	align-items: center;
-	margin-top: 0rem;
+	margin-top: 0.75rem;
+
+	&:has(> *:nth-child(2)) {
+		justify-content: center;
+	}
+
+	&:local(.stretch) > * {
+		width: calc(50% - 0.5rem);
+	}
+
+	&:local(.forceLeft) {
+		justify-content: flex-start;
+		margin-top: 2rem;
+	}
 }
 }
 

--- a/src/components/routes/Metadata/DistributionsList.jsx
+++ b/src/components/routes/Metadata/DistributionsList.jsx
@@ -32,6 +32,7 @@ const DistributionsList = (props) => {
                     visibleFields={["Type", "DownloadButton", "MapButton", "ApplicationButton", "DistributionFormats"]}
                     key={i}
                     enableThumbnail={false}
+                    buttonAlignment="left"
                 />
             );
         });


### PR DESCRIPTION
- When one button is present: forceLeft
- When two buttons are present: center and strech
- On metadata page/distribution list: align buttons leff. Also added som margin to top of buttons

Search results: 
<img width="1641" height="837" alt="Skjermbilde 2026-03-27 kl  12 00 27" src="https://github.com/user-attachments/assets/029640f0-f2c9-45af-bbdf-244fbc79c4f4" />

Distribution list:
<img width="1973" height="761" alt="Skjermbilde 2026-03-27 kl  12 02 12" src="https://github.com/user-attachments/assets/8480ce69-0169-4117-b22b-00e82fb97b62" />
