### PR TITLE
Fix search autocomplete popup appearing on back navigation

### DIFF
--- a/src/components/partials/MainNavigationContainer.jsx
+++ b/src/components/partials/MainNavigationContainer.jsx
@@ -30,6 +30,13 @@ const MainNavigationContainer = ({ userManager, layoutLoaderData }) => {
 
     // Refs
     const userRef = useRef(null);
+    const lastSearchStringRef = useRef(searchData?.searchString || "");
+
+    // Keep the last non-empty search string so navigating away and back
+    // doesn't reopen the autocomplete popup.
+    if (searchData?.searchString) {
+        lastSearchStringRef.current = searchData.searchString;
+    }
 
     const handleSubmitSearch = (searchString, selectedType) => {
         searchString = searchString.toString();
@@ -39,7 +46,7 @@ const MainNavigationContainer = ({ userManager, layoutLoaderData }) => {
             const isLoggedIn = !!auth?.user;
             if (isLoggedIn) {
                 //Todo fix problem when navigating https://medium.com/@fabrizio.azzarri/fixing-the-next-js-15-react-19-removechild-dom-error-a33b57cbc3b1
-                location.href= `/${selectedType}?text=${searchString}`;
+                location.href = `/${selectedType}?text=${searchString}`;
             }
             else{
             navigate(`/${selectedType}?text=${searchString}`);
@@ -160,7 +167,7 @@ const MainNavigationContainer = ({ userManager, layoutLoaderData }) => {
             },
             onSearchTypeChange: (event) => {
                 const searchType = event?.detail?.value || null;
-                handleChangeSearchResultsType(searchType, searchData?.searchString);
+                handleChangeSearchResultsType(searchType, lastSearchStringRef.current);
             },
             onMapItemsChange: (event) => {
                 dispatch(fetchMapItems());
@@ -169,7 +176,7 @@ const MainNavigationContainer = ({ userManager, layoutLoaderData }) => {
                 dispatch(fetchItemsToDownload());
             }
         });
-    }, [auth, baatInfo]);
+    }, [auth, baatInfo, searchData?.searchString]);
 
     const metadataResultsFound = searchData?.results?.metadata?.NumFound || 0;
     const articlesResultsFound = searchData?.results?.articles?.NumFound || 0;
@@ -191,7 +198,7 @@ const MainNavigationContainer = ({ userManager, layoutLoaderData }) => {
         isLoggedIn: !!auth.user,
         language: selectedLanguage,
         environment: getEnvironment(),
-        searchString: searchData?.searchString || "",
+        searchString: lastSearchStringRef.current,
         searchType: params.searchResultsType,
         showsearchtypeselector: true,//showSearchTypeSelector,
         metadataresultsfound: metadataResultsFound,


### PR DESCRIPTION
Problemet er at søkefeltet i headeren fyrte av `fetchDropdownSearchResults` hver gang søkestrengen endret seg. Navigering til en metadataside setter søkestrengen til å være tom. Når man da navigerer tilbake til søkresutltatene blir søkestrengen satt tilbake til det bruker søkte på, noe som trigget popup-en.

Dette er fikset ved å lagre den siste søkestrengen (som ikke er tom) slik at den er stabil også ved navigering.