### PR TITLE
Fix tag placement in metadata page

### DIFF
--- a/src/components/partials/SearchResults/MetadataSearchResult.module.scss
+++ b/src/components/partials/SearchResults/MetadataSearchResult.module.scss
@@ -189,6 +189,8 @@
       display:flex;
       flex-wrap:wrap;
       gap: 8px;
+      padding: 0;
+      list-style: none;
     }
   }
 }

--- a/src/components/routes/Metadata.module.scss
+++ b/src/components/routes/Metadata.module.scss
@@ -140,6 +140,8 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+    padding: 0;
+    list-style: none;
   }
 }
 
@@ -324,6 +326,8 @@
         display: flex;
         flex-wrap: wrap;
         gap: 8px;
+        padding: 0;
+        list-style: none;
       }
     }
 


### PR DESCRIPTION
<img width="1153" height="765" alt="Skjermbilde 2026-05-27 kl  10 29 39" src="https://github.com/user-attachments/assets/357134c4-218b-4f2d-ac96-05f5a3b898df" />
<img width="487" height="430" alt="Skjermbilde 2026-05-27 kl  10 29 51" src="https://github.com/user-attachments/assets/f82a4bea-e659-453a-8c85-6b19d56c4c11" />
<img width="1125" height="667" alt="Skjermbilde 2026-05-27 kl  10 30 03" src="https://github.com/user-attachments/assets/7e10a024-2468-41c5-8543-dd98cd3f6728" />
